### PR TITLE
".people" class css modification

### DIFF
--- a/css/LASTIG.css
+++ b/css/LASTIG.css
@@ -1062,8 +1062,8 @@ body.fr :lang(en){
 }
 
 .people{
-  display: inline-block;
-	height:200px;
+  display: inline-table;
+	height:auto;
 }
 
 .text-status{


### PR DESCRIPTION
# Correction of the vertical misalignment of the people portraits

**NB:** Only test on firefox 76

**Before changes :**

![before](https://user-images.githubusercontent.com/25084451/82882365-422a9900-9f41-11ea-95e6-1d778899c76a.png)


**After changes:**
![after](https://user-images.githubusercontent.com/25084451/82882376-448cf300-9f41-11ea-9cec-ad3c137dd4aa.png)



